### PR TITLE
make develop branch build as well

### DIFF
--- a/.github/workflows/package-deploy.yml
+++ b/.github/workflows/package-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - develop
 
 jobs:
   build:


### PR DESCRIPTION
We need a develop version of the build so we can use it in bi-api while it is in development. Since our versioning is setup to match the brapi version, our develop package version could be 2.0-SNAPSHOT as it is set up, and when we push a release to master it could be 2.0. 