### PR TITLE
BI-691 - Remove dataType query parameter from brapi-client calls

### DIFF
--- a/brapi-client/src/main/java/org/brapi/client/v2/modules/core/LocationsAPI.java
+++ b/brapi-client/src/main/java/org/brapi/client/v2/modules/core/LocationsAPI.java
@@ -54,7 +54,6 @@ public class LocationsAPI extends BrAPIEndpoint {
         String endpoint = BrAPICoreEndpoints_V2.getLocationsPath();
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .data(brApiLocations)
                 .method(HttpMethod.POST)
                 .build();
@@ -92,7 +91,6 @@ public class LocationsAPI extends BrAPIEndpoint {
         String endpoint = BrAPICoreEndpoints_V2.getLocationsByIdPath(brApiLocation.getLocationDbId());
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .data(brApiLocation)
                 .method(HttpMethod.PUT)
                 .build();
@@ -111,7 +109,6 @@ public class LocationsAPI extends BrAPIEndpoint {
         String endpoint = BrAPICoreEndpoints_V2.getLocationsPath();
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .parameters(locationsRequest.constructParameters())
                 .method(HttpMethod.GET)
                 .build();
@@ -136,7 +133,6 @@ public class LocationsAPI extends BrAPIEndpoint {
         String endpoint = BrAPICoreEndpoints_V2.getLocationsByIdPath(locationId);
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .method(HttpMethod.GET)
                 .build();
 

--- a/brapi-client/src/main/java/org/brapi/client/v2/modules/core/ProgramsAPI.java
+++ b/brapi-client/src/main/java/org/brapi/client/v2/modules/core/ProgramsAPI.java
@@ -50,7 +50,6 @@ public class ProgramsAPI extends BrAPIEndpoint {
         String endpoint = BrAPICoreEndpoints_V2.getProgramsPath();
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .parameters(programFilter.constructParameters())
                 .method(HttpMethod.GET)
                 .build();
@@ -79,7 +78,6 @@ public class ProgramsAPI extends BrAPIEndpoint {
         String endpoint = BrAPICoreEndpoints_V2.getProgramsByIdPath(programID);
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .method(HttpMethod.GET)
                 .build();
 
@@ -102,7 +100,6 @@ public class ProgramsAPI extends BrAPIEndpoint {
         String endpoint = BrAPICoreEndpoints_V2.getProgramsPath();
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .data(brApiPrograms)
                 .method(HttpMethod.POST)
                 .build();
@@ -139,7 +136,6 @@ public class ProgramsAPI extends BrAPIEndpoint {
         String endpoint = BrAPICoreEndpoints_V2.getProgramsByIdPath(brApiProgram.getProgramDbId());
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .data(brApiProgram)
                 .method(HttpMethod.PUT)
                 .build();

--- a/brapi-client/src/main/java/org/brapi/client/v2/modules/germplasm/GermplasmAPI.java
+++ b/brapi-client/src/main/java/org/brapi/client/v2/modules/germplasm/GermplasmAPI.java
@@ -44,7 +44,6 @@ public class GermplasmAPI extends BrAPIEndpoint {
         String endpoint = BrAPIGermplasmEndpoints_V2.getGermplasmPath();
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .parameters(germplasmFilter.constructParameters())
                 .method(HttpMethod.GET)
                 .build();
@@ -68,7 +67,6 @@ public class GermplasmAPI extends BrAPIEndpoint {
         String endpoint =BrAPIGermplasmEndpoints_V2.getGermplasmByIdPath(germplasmId);
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .method(HttpMethod.GET)
                 .build();
 
@@ -91,7 +89,6 @@ public class GermplasmAPI extends BrAPIEndpoint {
         String endpoint = BrAPIGermplasmEndpoints_V2.getGermplasmPath();
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .data(brApiGermplasm)
                 .method(HttpMethod.POST)
                 .build();
@@ -128,7 +125,6 @@ public class GermplasmAPI extends BrAPIEndpoint {
         String endpoint = BrAPIGermplasmEndpoints_V2.getGermplasmByIdPath(brApiGermplasm.getGermplasmDbId());
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .data(brApiGermplasm)
                 .method(HttpMethod.PUT)
                 .build();

--- a/brapi-client/src/main/java/org/brapi/client/v2/modules/phenotype/MethodsAPI.java
+++ b/brapi-client/src/main/java/org/brapi/client/v2/modules/phenotype/MethodsAPI.java
@@ -54,7 +54,6 @@ public class MethodsAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getMethodsPath();
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .data(brApiMethods)
                 .method(HttpMethod.POST)
                 .build();
@@ -92,7 +91,6 @@ public class MethodsAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getMethodsByIdPath(brApiMethod.getMethodDbId());
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .data(brApiMethod)
                 .method(HttpMethod.PUT)
                 .build();
@@ -111,7 +109,6 @@ public class MethodsAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getMethodsPath();
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .parameters(methodsRequest.constructParameters())
                 .method(HttpMethod.GET)
                 .build();
@@ -136,7 +133,6 @@ public class MethodsAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getMethodsByIdPath(methodId);
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .method(HttpMethod.GET)
                 .build();
 

--- a/brapi-client/src/main/java/org/brapi/client/v2/modules/phenotype/ScalesAPI.java
+++ b/brapi-client/src/main/java/org/brapi/client/v2/modules/phenotype/ScalesAPI.java
@@ -54,7 +54,6 @@ public class ScalesAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getScalesPath();
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .data(brApiScales)
                 .method(HttpMethod.POST)
                 .build();
@@ -92,7 +91,6 @@ public class ScalesAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getScalesByIdPath(brApiScale.getScaleDbId());
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .data(brApiScale)
                 .method(HttpMethod.PUT)
                 .build();
@@ -111,7 +109,6 @@ public class ScalesAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getScalesPath();
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .parameters(scalesRequest.constructParameters())
                 .method(HttpMethod.GET)
                 .build();
@@ -136,7 +133,6 @@ public class ScalesAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getScalesByIdPath(scaleId);
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .method(HttpMethod.GET)
                 .build();
 

--- a/brapi-client/src/main/java/org/brapi/client/v2/modules/phenotype/TraitsAPI.java
+++ b/brapi-client/src/main/java/org/brapi/client/v2/modules/phenotype/TraitsAPI.java
@@ -48,7 +48,6 @@ public class TraitsAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getTraitsPath();
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .parameters(traitsRequest.constructParameters())
                 .method(HttpMethod.GET)
                 .build();
@@ -77,7 +76,6 @@ public class TraitsAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getTraitsByIdPath(traitId);
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .method(HttpMethod.GET)
                 .build();
 
@@ -99,7 +97,6 @@ public class TraitsAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getTraitsPath();
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .data(brApiTraits)
                 .method(HttpMethod.POST)
                 .build();
@@ -136,7 +133,6 @@ public class TraitsAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getTraitsByIdPath(brApiTrait.getTraitDbId());
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .data(brApiTrait)
                 .method(HttpMethod.PUT)
                 .build();

--- a/brapi-client/src/main/java/org/brapi/client/v2/modules/phenotype/VariablesAPI.java
+++ b/brapi-client/src/main/java/org/brapi/client/v2/modules/phenotype/VariablesAPI.java
@@ -54,7 +54,6 @@ public class VariablesAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getVariablesPath();
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .data(brApiVariables)
                 .method(HttpMethod.POST)
                 .build();
@@ -92,7 +91,6 @@ public class VariablesAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getVariablesByIdPath(brApiVariable.getObservationVariableDbId());
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .data(brApiVariable)
                 .method(HttpMethod.PUT)
                 .build();
@@ -111,7 +109,6 @@ public class VariablesAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getVariablesPath();
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .parameters(variablesRequest.constructParameters())
                 .method(HttpMethod.GET)
                 .build();
@@ -136,7 +133,6 @@ public class VariablesAPI extends BrAPIEndpoint {
         String endpoint = BrAPIPhenotypeEndpoints_V2.getVariablesByIdPath(variableId);
         BrAPIRequest request = BrAPIRequest.builder()
                 .target(endpoint)
-                .parameter("dataType", "application/json")
                 .method(HttpMethod.GET)
                 .build();
 

--- a/brapi-client/src/test/java/org/brapi/client/v2/BrAPIClientTest.java
+++ b/brapi-client/src/test/java/org/brapi/client/v2/BrAPIClientTest.java
@@ -25,7 +25,7 @@ public class BrAPIClientTest {
     protected BrAPIClient client;
 
     public BrAPIClientTest() {
-        brapiTestServer = "https://test-server.brapi.org/";
+        brapiTestServer = "https://test-server.brapi.org";
         client = new BrAPIClient(brapiTestServer);
     }
 


### PR DESCRIPTION
## Changes
- Removed unused dataType query parameters from brapi client requests
- Talked w/ Tim & Pete, may have been used way back in v1 but not anymore