### PR TITLE
[BI-761] handle all exceptions from response

### DIFF
--- a/brapi-java-client/src/main/java/org/brapi/client/v2/BrAPIClient.java
+++ b/brapi-java-client/src/main/java/org/brapi/client/v2/BrAPIClient.java
@@ -819,6 +819,9 @@ public class BrAPIClient {
 				} catch (ApiException e) {
 					callback.onFailure(e, response.code(), response.headers().toMultimap());
 					return;
+				}catch (Exception e) {
+					callback.onFailure(new ApiException(e), response.code(), response.headers().toMultimap());
+					return;
 				}
 				callback.onSuccess(result, response.code(), response.headers().toMultimap());
 			}


### PR DESCRIPTION
There was an unhandled JSON deserialize exception which was causing Field Book to crash.
This code transfers all exceptions to `APIException` while handling the response, so that Field Book (or other client) can handle the exception gracefully
This code is tested with Field Book for this scenario, but not more generally.