### PR TITLE
fixes #30

### DIFF
--- a/brapi-java-client/src/main/java/org/brapi/client/v2/typeAdapters/OffsetDateTimeTypeAdapter.java
+++ b/brapi-java-client/src/main/java/org/brapi/client/v2/typeAdapters/OffsetDateTimeTypeAdapter.java
@@ -47,7 +47,14 @@ public class OffsetDateTimeTypeAdapter extends TypeAdapter<OffsetDateTime> {
                 if (date.endsWith("+0000")) {
                     date = date.substring(0, date.length()-5) + "Z";
                 }
-                return OffsetDateTime.parse(date, formatter);
+                //catch any date parsing exception, set to null if exception occurs
+                OffsetDateTime parsedDate;
+                try {
+                    parsedDate = OffsetDateTime.parse(date, formatter);
+                } catch (java.time.format.DateTimeParseException e) {
+                    parsedDate = null;
+                }
+                return parsedDate;
         }
     }
 }


### PR DESCRIPTION
added parse exception handling for OffsetDateTimeTypeAdapter

issue:
Exception causes no studies to be returned.

fix:
catch any offset date time parsing exception, if one occurs, set the offset date time to null.