### PR TITLE
Fix RuntimeException in locations search deserialization

### DIFF
--- a/brapi-java-client/src/main/java/org/brapi/client/v2/BrAPIClient.java
+++ b/brapi-java-client/src/main/java/org/brapi/client/v2/BrAPIClient.java
@@ -71,7 +71,6 @@ public class BrAPIClient {
 
 	private OkHttpClient httpClient;
 	private JSON json;
-	private Gson gson;
 
 	public BrAPIClient() {
 		setBasePath("");
@@ -96,12 +95,7 @@ public class BrAPIClient {
 				.build();
 		verifyingSsl = true;
 		json = new JSON();
-		gson = new GsonBuilder()
-				.registerTypeAdapter(OffsetDateTime.class, (JsonDeserializer<OffsetDateTime>)
-						(json, type, context) -> OffsetDateTime.parse(json.getAsString()))
-				.registerTypeAdapter(LocalDate.class, (JsonDeserializer<LocalDate>)
-						(json, type, context) -> LocalDate.parse(json.getAsString()))
-				.create();
+
 		// Set default User-Agent.
 		setUserAgent("brapi-java-client/2.0");
 		// Setup authentications (key: authentication name, value: authentication).
@@ -815,11 +809,11 @@ public class BrAPIClient {
 			try {
 				if (searchResult != null && searchResult.get("searchResultsDbId") != null) {
 					// Parse into a BrAPI Accepted Search Response
-					BrAPIAcceptedSearchResponse searchResultObject = gson.fromJson(searchBody, BrAPIAcceptedSearchResponse.class);
+					BrAPIAcceptedSearchResponse searchResultObject = json.getGson().fromJson(searchBody, BrAPIAcceptedSearchResponse.class);
 					result = new ImmutablePair<>(Optional.empty(), Optional.of(searchResultObject));
 				} else {
 					// Parse into the actual response object
-					T listResponse = gson.fromJson(searchBody, returnType);
+					T listResponse = json.getGson().fromJson(searchBody, returnType);
 					result = new ImmutablePair<>(Optional.of(listResponse), Optional.empty());
 				}
 			} catch (JsonSyntaxException e){

--- a/brapi-java-client/src/test/java/org/brapi/client/v2/modules/core/LocationsAPITests.java
+++ b/brapi-java-client/src/test/java/org/brapi/client/v2/modules/core/LocationsAPITests.java
@@ -24,13 +24,16 @@ import com.github.filosganga.geogson.model.positions.SinglePosition;
 import com.google.gson.JsonObject;
 import lombok.SneakyThrows;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.BrAPIClientTest;
 import org.brapi.client.v2.model.exceptions.ApiException;
 import org.brapi.client.v2.model.queryParams.core.LocationQueryParams;
+import org.brapi.v2.model.BrAPIAcceptedSearchResponse;
 import org.brapi.v2.model.BrApiGeoJSON;
 import org.brapi.v2.model.BrAPIExternalReference;
 import org.brapi.v2.model.core.BrAPILocation;
+import org.brapi.v2.model.core.request.BrAPILocationSearchRequest;
 import org.brapi.v2.model.core.response.BrAPILocationListResponse;
 import org.brapi.v2.model.core.response.BrAPILocationSingleResponse;
 import org.junit.jupiter.api.*;
@@ -322,6 +325,21 @@ public class LocationsAPITests extends BrAPIClientTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             ApiResponse<BrAPILocationSingleResponse> updatedLocationResult = this.locationsAPI.locationsLocationDbIdPut(null, null);
         });
+    }
+
+    @Test
+    @Order(3)
+    @SneakyThrows
+    public void searchLocationByName() {
+        BrAPILocationSearchRequest locationSearchRequest = new BrAPILocationSearchRequest();
+        List<String> names = new ArrayList<>();
+        names.add("updated_name");
+        locationSearchRequest.setLocationNames(names);
+        ApiResponse<Pair<Optional<BrAPILocationListResponse>, Optional<BrAPIAcceptedSearchResponse>>> response = locationsAPI.searchLocationsPost(locationSearchRequest);
+        BrAPILocationListResponse locationResponse = response.getBody().getLeft().get();
+
+        assertEquals(true, locationResponse.getResult().getData().size() > 0, "List of locations was empty");
+
     }
 
 }


### PR DESCRIPTION
Was getting error `java.lang.RuntimeException: Unable to invoke no-args constructor for interface com.github.filosganga.geogson.model.Geometry. Registering an InstanceCreator with Gson for this type may fix this problem` when using `LocationsApi::searchLocationsPost`. This was because the gson instance being used for deserialization did not have the GeometryTypeAdapterFactory registered.

**Summary of changes**
- Added test case for this error and verified it passes after fix
- Removed gson instance in BrAPI client because the JSON class gson instance should be used instead
- Switched to using JSON class gson with correctly registered type adapters in `BrAPIClient::executeSearch`