### PR TITLE
BI-2019 - Pedigree Viewer Not Rendering

### DIFF
--- a/brapi-java-client/src/test/java/org/brapi/client/v2/modules/germplasm/PedigreeAPITests.java
+++ b/brapi-java-client/src/test/java/org/brapi/client/v2/modules/germplasm/PedigreeAPITests.java
@@ -17,6 +17,8 @@
 
 package org.brapi.client.v2.modules.germplasm;
 
+import com.google.gson.JsonObject;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.brapi.client.v2.ApiResponse;
 import org.brapi.client.v2.BrAPIClientTest;
@@ -109,8 +111,8 @@ public class PedigreeAPITests extends BrAPIClientTest {
     @Test
     public void createPedigreeSuccess() throws Exception {
 
-        Map<String, String> additionalInfo = new HashMap<String, String>();
-        additionalInfo.put("test_key", "test_value");
+        JsonObject additionalInfo = new JsonObject();
+        additionalInfo.addProperty("test_key", "test_value");
         List<BrAPIExternalReference> externalReferences = new ArrayList<>();
         externalReferences.add(new BrAPIExternalReference()
                 .referenceID(UUID.randomUUID().toString())

--- a/brapi-java-model/src/main/java/org/brapi/v2/model/germ/BrAPIPedigreeNode.java
+++ b/brapi-java-model/src/main/java/org/brapi/v2/model/germ/BrAPIPedigreeNode.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import com.google.gson.JsonObject;
 import org.brapi.v2.model.BrAPIExternalReference;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -28,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class BrAPIPedigreeNode {
     @JsonProperty("additionalInfo")
-    private Map<String, String> additionalInfo = null;
+    private JsonObject additionalInfo = null;
 
     @JsonProperty("breedingMethodDbId")
     private String breedingMethodDbId = null;
@@ -76,16 +77,16 @@ public class BrAPIPedigreeNode {
     @JsonProperty("siblings")
     private List<BrAPIPedigreeNodeSibling> siblings = null;
 
-    public BrAPIPedigreeNode additionalInfo(Map<String, String> additionalInfo) {
+    public BrAPIPedigreeNode additionalInfo(JsonObject additionalInfo) {
         this.additionalInfo = additionalInfo;
         return this;
     }
 
     public BrAPIPedigreeNode putAdditionalInfoItem(String key, String additionalInfoItem) {
         if (this.additionalInfo == null) {
-            this.additionalInfo = new HashMap<String, String>();
+            this.additionalInfo = new JsonObject();
         }
-        this.additionalInfo.put(key, additionalInfoItem);
+        this.additionalInfo.addProperty(key, additionalInfoItem);
         return this;
     }
 
@@ -94,11 +95,11 @@ public class BrAPIPedigreeNode {
      *
      * @return additionalInfo
      **/
-    public Map<String, String> getAdditionalInfo() {
+    public JsonObject getAdditionalInfo() {
         return additionalInfo;
     }
 
-    public void setAdditionalInfo(Map<String, String> additionalInfo) {
+    public void setAdditionalInfo(JsonObject additionalInfo) {
         this.additionalInfo = additionalInfo;
     }
 


### PR DESCRIPTION
## Description
[Jira Story](https://breedinginsight.atlassian.net/browse/BI-2019)

This PR completes the work that was done in [this commit](https://github.com/Breeding-Insight/brapi/commit/bb2be6ed287d4cd201c08f3d9d43860ee5a6e2a2) to type `additionalInfo` fields as `JsonObject`.

The brapi-java-client was trying to parse `additionalInfo` on `BrAPIPedigreeNode` objects, which can have nested objects, as a strict Map<String, String>, which resulted in the error `Expected a string but was BEGIN_OBJECT`.

>The bug does not occur with BreedBase-backed programs, because BreedBase doesn’t include `additionalInfo` in the response to the `brapi/v2/germplasm/<germplasmId>/pedigree` call.


## Testing
Step 0. [OPTIONAL] Reproduce the bug by running bi-web and bi-api, uploading germplasm to a BJTS program and trying to use the pedigree viewer.

1. Clone: `git clone https://github.com/Breeding-Insight/brapi`.
2. Open brapi in IntelliJ IDEA.
3. Checkout this branch: `git checkout bug/BI-2019`.
4. Create and run a maven configuration in IntelliJ IDEA with the following run command: `clean install -D maven.test.skip=true` (with the root directory of the repo ("brapi") as the working directory).
5. Open bi-api in IntelliJ IDEA.
6. Find the `brapi-java-client` dependency and replace it with the following, substituting the absolute path to the brapi repo on your local machine for {PATH_TO_BRAPI_REPO}.
```xml
        <dependency>
            <groupId>org.brapi</groupId>
            <artifactId>brapi-java-client</artifactId>
            <version>${brapi-java-client.version}</version>
            <scope>system</scope>
            <systemPath>{PATH_TO_BRAPI_REPO}/brapi-java-client/target/brapi-java-client-2.1-SNAPSHOT.jar</systemPath>
        </dependency>
        <dependency>
            <groupId>org.brapi</groupId>
            <artifactId>brapi-java-model</artifactId>
            <version>${brapi-java-client.version}</version>
            <scope>system</scope>
            <systemPath>{PATH_TO_BRAPI_REPO}/brapi-java-model/target/brapi-java-model-2.1-SNAPSHOT.jar</systemPath>
        </dependency>
        <dependency>
            <groupId>com.github.filosganga</groupId>
            <artifactId>geogson-core</artifactId>
            <version>1.2.21</version>
        </dependency>
```
7. [OPTIONAL] Open the maven tool window and reload all maven projects - try this if you get build errors.
8. Build bi-api as you normally do. My run config is shown below.
<img width="1017" alt="image" src="https://github.com/Breeding-Insight/brapi/assets/128052931/e3a9422a-0f65-4ed4-9dc3-c5c824bb567a">
9. With bi-web and bi-api running, verify that the pedigree viewer works for germplasm uploaded to a BJTS program.

___

These general steps have been documented on Confluence, https://breedinginsight.atlassian.net/wiki/x/AQC6dg, please add anything you learn in the process of testing there.