### PR TITLE
Add support for SortBy and FilterBy updates to prod server for usage by bi-api

### DIFF
--- a/brapi-java-client/pom.xml
+++ b/brapi-java-client/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.brapi</groupId>
         <artifactId>brapi</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/brapi-java-model/pom.xml
+++ b/brapi-java-model/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.brapi</groupId>
         <artifactId>brapi</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/brapi-java-model/src/main/java/org/brapi/v2/model/BrAPIFilterBy.java
+++ b/brapi-java-model/src/main/java/org/brapi/v2/model/BrAPIFilterBy.java
@@ -1,0 +1,22 @@
+package org.brapi.v2.model;
+
+public class BrAPIFilterBy {
+    private String filterOn;
+    private String value;
+
+    public String getFilterOn() {
+        return filterOn;
+    }
+
+    public void setFilterOn(String filterOn) {
+        this.filterOn = filterOn;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/brapi-java-model/src/main/java/org/brapi/v2/model/BrAPISearchRequestParametersPaging.java
+++ b/brapi-java-model/src/main/java/org/brapi/v2/model/BrAPISearchRequestParametersPaging.java
@@ -1,16 +1,11 @@
 package org.brapi.v2.model;
 
+import java.util.List;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-
-
-
-
 /**
  * SearchRequestParametersPaging
  */
-
 
 public class BrAPISearchRequestParametersPaging   {
   @JsonProperty("page")
@@ -18,6 +13,12 @@ public class BrAPISearchRequestParametersPaging   {
 
   @JsonProperty("pageSize")
   private Integer pageSize = null;
+
+  @JsonProperty("sortBy")
+  protected List<BrAPISortBy> sortBy = null;
+
+  @JsonProperty("filterBy")
+  protected List<BrAPIFilterBy> filterBy = null;
 
   public BrAPISearchRequestParametersPaging page(Integer page) {
     this.page = page;
@@ -57,6 +58,21 @@ public class BrAPISearchRequestParametersPaging   {
     this.pageSize = pageSize;
   }
 
+  public List<BrAPISortBy> getSortBy() {
+    return sortBy;
+  }
+
+  public void setSortBy(List<BrAPISortBy> sortBy) {
+    this.sortBy = sortBy;
+  }
+
+  public List<BrAPIFilterBy> getFilterBy() {
+    return filterBy;
+  }
+
+  public void setFilterBy(List<BrAPIFilterBy> filterBy) {
+    this.filterBy = filterBy;
+  }
 
   @Override
   public boolean equals(java.lang.Object o) {

--- a/brapi-java-model/src/main/java/org/brapi/v2/model/BrAPISortBy.java
+++ b/brapi-java-model/src/main/java/org/brapi/v2/model/BrAPISortBy.java
@@ -1,62 +1,30 @@
 package org.brapi.v2.model;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+public class BrAPISortBy {
+    private String sortedOn;
+    private BrAPISortOrder  sortOrder = BrAPISortOrder.ASC;
 
-public enum BrAPISortBy implements BrAPIEnum {
-
-    STUDYDBID("studyDbId"),
-
-    STARTDATE("startDate"),
-
-    ENDDATE("endDate"),
-    
-    TRIALDBID("trialDbId"),
-    
-    TRIALNAME("trialName"),
-    
-    PROGRAMDBID("programDbId"),
-    
-    LOCATIONDBID("locationDbId"),
-    
-    SEASONDBID("seasonDbId"),
-    
-    STUDYTYPE("studyType"),
-    
-    STUDYNAME("studyName"),
-    
-    STUDYLOCATION("studyLocation"),
-    
-    PROGRAMNAME("programName"),
-    
-    GERMPLASMDBID("germplasmDbId"),
-    
-    OBSERVATIONVARIABLEDBID("observationVariableDbId");
-
-    private String value;
-
-    BrAPISortBy(String value) {
-      this.value = value;
+    public BrAPISortBy(String sortedOn,
+                  BrAPISortOrder sortOrder) {
+        this.sortedOn = sortedOn;
+        this.sortOrder = sortOrder;
     }
 
-    @Override
-    @JsonValue
-    public String toString() {
-      return String.valueOf(value);
+    public BrAPISortBy() {}
+
+    public String getSortedOn() {
+        return sortedOn;
     }
 
-    @JsonCreator
-    public static BrAPISortBy fromValue(String text) {
-      for (BrAPISortBy b : BrAPISortBy.values()) {
-        if (String.valueOf(b.value).equals(text)) {
-          return b;
-        }
-      }
-      return null;
+    public void setSortedOn(String sortedOn) {
+        this.sortedOn = sortedOn;
     }
 
-	@Override
-	public String getBrapiValue() {
-		return value;
-	}
+    public BrAPISortOrder getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(BrAPISortOrder sortOrder) {
+        this.sortOrder = sortOrder;
+    }
 }

--- a/brapi-java-model/src/main/java/org/brapi/v2/model/core/request/BrAPIStudySearchRequest.java
+++ b/brapi-java-model/src/main/java/org/brapi/v2/model/core/request/BrAPIStudySearchRequest.java
@@ -74,12 +74,6 @@ public class BrAPIStudySearchRequest extends BrAPISearchRequestParametersPaging 
 	@JsonProperty("seasonDbIds")
 	private List<String> seasonDbIds = null;
 
-	@JsonProperty("sortBy")
-	private BrAPISortBy sortBy = null;
-
-	@JsonProperty("sortOrder")
-	private BrAPISortOrder sortOrder = null;
-
 	@JsonProperty("studyCodes")
 	private List<String> studyCodes = null;
 
@@ -598,45 +592,6 @@ public class BrAPIStudySearchRequest extends BrAPISearchRequestParametersPaging 
 		this.seasonDbIds = seasonDbIds;
 	}
 
-	public BrAPIStudySearchRequest sortBy(BrAPISortBy sortBy) {
-		this.sortBy = sortBy;
-		return this;
-	}
-
-	/**
-	 * Name of one of the fields within the study object on which results can be
-	 * sorted
-	 * 
-	 * @return sortBy
-	 **/
-
-	public BrAPISortBy getSortBy() {
-		return sortBy;
-	}
-
-	public void setSortBy(BrAPISortBy sortBy) {
-		this.sortBy = sortBy;
-	}
-
-	public BrAPIStudySearchRequest sortOrder(BrAPISortOrder sortOrder) {
-		this.sortOrder = sortOrder;
-		return this;
-	}
-
-	/**
-	 * Order results should be sorted. ex. \"ASC\" or \"DESC\"
-	 * 
-	 * @return sortOrder
-	 **/
-
-	public BrAPISortOrder getSortOrder() {
-		return sortOrder;
-	}
-
-	public void setSortOrder(BrAPISortOrder sortOrder) {
-		this.sortOrder = sortOrder;
-	}
-
 	public BrAPIStudySearchRequest studyCodes(List<String> studyCodes) {
 		this.studyCodes = studyCodes;
 		return this;
@@ -748,7 +703,6 @@ public class BrAPIStudySearchRequest extends BrAPISearchRequestParametersPaging 
 				&& Objects.equals(this.active, studySearchRequest.active)
 				&& Objects.equals(this.seasonDbIds, studySearchRequest.seasonDbIds)
 				&& Objects.equals(this.sortBy, studySearchRequest.sortBy)
-				&& Objects.equals(this.sortOrder, studySearchRequest.sortOrder)
 				&& Objects.equals(this.studyCodes, studySearchRequest.studyCodes)
 				&& Objects.equals(this.studyPUIs, studySearchRequest.studyPUIs)
 				&& Objects.equals(this.studyTypes, studySearchRequest.studyTypes) && super.equals(o);
@@ -759,7 +713,7 @@ public class BrAPIStudySearchRequest extends BrAPISearchRequestParametersPaging 
 		return Objects.hash(commonCropNames, programDbIds, programNames, trialDbIds, trialNames, studyDbIds, studyNames,
 				locationDbIds, locationNames, germplasmDbIds, germplasmNames, observationVariableDbIds,
 				observationVariableNames, observationVariablePUIs, externalReferenceIds, externalReferenceIDs,
-				externalReferenceSources, active, seasonDbIds, sortBy, sortOrder, studyCodes, studyPUIs, studyTypes,
+				externalReferenceSources, active, seasonDbIds, sortBy, studyCodes, studyPUIs, studyTypes,
 				super.hashCode());
 	}
 
@@ -788,7 +742,6 @@ public class BrAPIStudySearchRequest extends BrAPISearchRequestParametersPaging 
 		sb.append("    active: ").append(toIndentedString(active)).append("\n");
 		sb.append("    seasonDbIds: ").append(toIndentedString(seasonDbIds)).append("\n");
 		sb.append("    sortBy: ").append(toIndentedString(sortBy)).append("\n");
-		sb.append("    sortOrder: ").append(toIndentedString(sortOrder)).append("\n");
 		sb.append("    studyCodes: ").append(toIndentedString(studyCodes)).append("\n");
 		sb.append("    studyPUIs: ").append(toIndentedString(studyPUIs)).append("\n");
 		sb.append("    studyTypes: ").append(toIndentedString(studyTypes)).append("\n");

--- a/brapi-java-model/src/main/java/org/brapi/v2/model/core/request/BrAPITrialSearchRequest.java
+++ b/brapi-java-model/src/main/java/org/brapi/v2/model/core/request/BrAPITrialSearchRequest.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.time.LocalDate;
 
 import org.brapi.v2.model.BrAPISearchRequestParametersPaging;
-import org.brapi.v2.model.BrAPISortBy;
-import org.brapi.v2.model.BrAPISortOrder;
 
 /**
  * TrialSearchRequest
@@ -67,28 +65,6 @@ public class BrAPITrialSearchRequest extends BrAPISearchRequestParametersPaging 
 
 	@JsonProperty("trialPUIs")
 	private List<String> trialPUIs = null;
-
-	@JsonProperty("sortBy")
-	private BrAPISortBy sortBy = null;
-
-	@JsonProperty("sortOrder")
-	private BrAPISortOrder sortOrder = null;
-
-	public BrAPISortBy getSortBy() {
-		return sortBy;
-	}
-
-	public void setSortBy(BrAPISortBy sortBy) {
-		this.sortBy = sortBy;
-	}
-
-	public BrAPISortOrder getSortOrder() {
-		return sortOrder;
-	}
-
-	public void setSortOrder(BrAPISortOrder sortOrder) {
-		this.sortOrder = sortOrder;
-	}
 
 	public BrAPITrialSearchRequest commonCropNames(List<String> commonCropNames) {
 		this.commonCropNames = commonCropNames;

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>org.brapi</groupId>
   <artifactId>brapi</artifactId>
-  <version>2.2-SNAPSHOT</version>
+  <version>2.2.1-SNAPSHOT</version>
 
   <name>${project.artifactId}</name>
   <url>https://github.com/Breeding-Insight/brapi</url>


### PR DESCRIPTION
# Description
**Story:** [BI-2861](https://breedinginsight.atlassian.net/browse/BI-2861)

To support the removal of the cache for TrialEntities, a generalized implementation of filtering and sorting was created for the prod server. 

Changes to the brapi-model were made to support these changes to be picked up and utilized by bi-api:

- New filter/sort models available to all search requests
- Updated version number

# Dependencies
- [java-prod-server](https://github.com/Breeding-Insight/brapi-Java-ProdServer/pull/17)
- [bi-api](https://github.com/Breeding-Insight/bi-api/pull/521)
# Testing
- Test filtering and sorting of Trials by messing around with the different functionalities of the data table in the `Experiments` tab of a Program.  Mess with filtering, testing case insensitivity, and different data types.  For sorting, test the order of different columns and ASC vs DESC order.  Mess with paging, try selecting different pages, and different number of records per page


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2861]: https://breedinginsight.atlassian.net/browse/BI-2861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ